### PR TITLE
ci: changed to $GITHUB_OUTPUT from set-output

### DIFF
--- a/.github/workflows/jaotan-review.yml
+++ b/.github/workflows/jaotan-review.yml
@@ -1,0 +1,17 @@
+name: Review by jaotan
+
+on:
+  issue_comment:
+    types: [ created ]
+
+jobs:
+  review:
+    runs-on: ubuntu-latest
+    if: github.event.issue.pull_request != null && github.event.sender.id == 8929706 && contains(github.event.comment.body, '@jaotan') && contains(github.event.comment.body, 'review')
+
+    steps:
+      - name: Review
+        run:
+          gh pr review ${{ github.event.issue.number }} -R "$GITHUB_REPOSITORY" -a -b "It was reviewed by a request by comment."
+        env:
+          GITHUB_TOKEN: ${{ secrets.PERSONAL_ACCESS_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,7 +28,7 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           default_bump: "minor"
-          custom_release_rules: "feat:minor:✨ Features,fix:patch:🐛 Bug Fixes,docs:patch:📰 Docs,chore:patch:🎨 Chore,pref:patch:🎈 Performance improvements,refactor:patch:🧹 Refactoring,build:patch:🔍 Build,ci:patch:🔍 CI,revert:patch:⏪ Revert,style:patch:🧹 Style,test:patch:👀 Test"
+          custom_release_rules: "feat:minor:✨ Features,fix:patch:🐛 Fixes,docs:patch:📰 Docs,chore:patch:🎨 Chore,pref:patch:🎈 Performance improvements,refactor:patch:🧹 Refactoring,build:patch:🔍 Build,ci:patch:🔍 CI,revert:patch:⏪ Revert,style:patch:🧹 Style,test:patch:👀 Test"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v2
@@ -52,7 +52,7 @@ jobs:
       - name: Set PROJECT_NAME
         id: vars
         run: |
-          echo "::set-output name=PROJECT_NAME::`TOP=$(git rev-parse --show-toplevel); echo ${TOP##*/}`"
+          echo "PROJECT_NAME=`TOP=$(git rev-parse --show-toplevel); echo ${TOP##*/}`" >> $GITHUB_OUTPUT
 
       - name: Build with Maven
         run: mvn -B package --file pom.xml


### PR DESCRIPTION
https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/